### PR TITLE
add -serial option to select ST-LINK by serial number

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,14 +42,16 @@
             "name": "(gdb) Linux",
             "type": "cppdbg",
             "request": "launch",
-            // Resolved by CMake Tools:
+            // Resolved by CMake Tools:            
             "program": "${command:cmake.launchTargetPath}",
             "args": [
                 "-ram",
                 "32",
                 "-v",
                 "4",
-                "-rtcp",
+                "-serial",
+                "000C001B4142500720353451"
+                // "003D003B3137510939383538",
             ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Options:
 
 **-ap** select the AP number to use (default 0), some devices have multiple APs, for example STM32H5 and STM32H7 need set AP to 1.
 
+**-serial** ST-LINK serial number to connect to. Useful when multiple ST-LINK probes are connected at the same time.
+
 # Executable
 
 Can be found [here](https://github.com/phryniszak/strtt/releases).
@@ -30,6 +32,10 @@ alt="RTT and STM32CubeIDE" width="480" height="360" border="10" /></a>
 
 To share ST-LINK_gdbserver add **-t** option to serverArgs and start strtt with **-tcp**.
 
+# Known Limitations
+
+> **Cortex-M7 devices:** Due to unresolved cache handling issues inherited from the OpenOCD driver, the program may fail to work correctly with Cortex-M7 based devices (e.g. STM32F7, STM32H7).
+
 # Internals
 
 Program is using a refactored driver from the openocd project.
@@ -45,6 +51,10 @@ Program is using a refactored driver from the openocd project.
 # If you want to connect to RTT while debugging in your IDE share stlink and use tcp
 
 ./strtt -ramstart 0x30020000 -tcp
+
+# If multiple ST-LINK probes are connected, select one by serial number
+
+./strtt -serial 066EFF303435554157105544
 
 ```
 

--- a/src/openocd/adapter.c
+++ b/src/openocd/adapter.c
@@ -79,7 +79,7 @@ openjtag, osbdm, presto, rlink, st-link, usb_blaster (ublast2), usbprog, vsllink
 @end deffn
 */
 
-static void adapter_set_required_serial(const char *serial)
+void adapter_set_required_serial(const char *serial)
 {
 	free(adapter_config.serial);
 	adapter_config.serial = strdup(serial);

--- a/src/openocd/adapter.h
+++ b/src/openocd/adapter.h
@@ -9,6 +9,10 @@
 
 #include "helper_types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Initialize debug adapter upon startup.  */
 // int adapter_init(struct command_context *cmd_ctx);
 
@@ -50,5 +54,12 @@ bool adapter_usb_location_equal(uint8_t dev_bus, uint8_t *port_path, size_t path
 
 /** Retrieves the serial number set with command 'adapter serial' */
 const char *adapter_get_required_serial(void);
+
+/** Sets the serial number string used to filter adapter selection */
+void adapter_set_required_serial(const char *serial);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* OPENOCD_JTAG_ADAPTER_H */

--- a/src/openocd/stlink.c
+++ b/src/openocd/stlink.c
@@ -1150,6 +1150,7 @@ static int stlink_usb_error_check(void *handle)
 
 	switch (h->databuf[0])
 	{
+	case 0x00: /* ST-LINK V3 returns 0x00 for OK instead of 0x80 */
 	case STLINK_DEBUG_ERR_OK:
 		return ERROR_OK;
 	case STLINK_DEBUG_ERR_FAULT:

--- a/src/rtt/strttapp.cpp
+++ b/src/rtt/strttapp.cpp
@@ -9,6 +9,7 @@
 #include "log.h"
 #include "inputparser.h"
 #include "consoleinput.h"
+#include "adapter.h"
 
 // #define SYSVIEW
 
@@ -56,6 +57,7 @@ static void showArgs(const std::string& progName)
     std::cout << "  -t\t\t ... show cycle time " << std::endl;
     std::cout << "  -tcp\t\t ... use TCP connection " << std::endl;
     std::cout << "  -ap number\t ... accessport number" << std::endl;
+    std::cout << "  -serial string\t ... ST-LINK serial number to connect to" << std::endl;
 }
 
 // INFO:
@@ -81,14 +83,15 @@ int main(int argc, char **argv)
     }
 
     debug_level            = LOG_LVL_SILENT;
-    int      _ramKB        = 16;
-    int      port          = SYSVIEW_COMM_SERVER_PORT;
-    uint32_t _ramStart     = RAM_START;
-    uint8_t  apNum         = 0;
-    bool     useTCP        = false;
-    bool     showCycleTime = false;
+    int         _ramKB        = 16;
+    int         port          = SYSVIEW_COMM_SERVER_PORT;
+    uint32_t    _ramStart     = RAM_START;
+    uint8_t     apNum         = 0;
+    bool        useTCP        = false;
+    bool        showCycleTime = false;
+    std::string serial;
 
-    auto handleOptions = [&argc, argv, &_ramKB, &port, &_ramStart, &apNum, &useTCP, &showCycleTime]() {
+    auto handleOptions = [&argc, argv, &_ramKB, &port, &_ramStart, &apNum, &useTCP, &showCycleTime, &serial]() {
         InputParser input(argc, argv);
 
         if( input.cmdOptionExists("-v") ) {
@@ -131,6 +134,10 @@ int main(int argc, char **argv)
         if( input.cmdOptionExists("-ap") ) {
             apNum = std::stoi(input.getCmdOption("-ap"));
         }
+
+        if( input.cmdOptionExists("-serial") ) {
+            serial = input.getCmdOption("-serial");
+        }
     };
 
     try {
@@ -140,6 +147,9 @@ int main(int argc, char **argv)
         showArgs(argv[0]);
         return EXIT_FAILURE;
     }
+
+    if (!serial.empty())
+        adapter_set_required_serial(serial.c_str());
 
     auto strtt = std::make_unique<StRtt>(_ramStart, apNum);
 


### PR DESCRIPTION
Expose adapter_set_required_serial() so strttapp can pass a serial number filter before opening the device. The filtering logic already existed in jtag_libusb_open(); this wires it up from the CLI.

Also fix ST-LINK V3 returning 0x00 (instead of 0x80) as the OK status code, and document the Cortex-M7 cache limitation in README.